### PR TITLE
Fix getopt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
     </dependency>
 	<!-- third party -->
     <dependency>
-      <groupId>gnu-getopt</groupId>
-      <artifactId>getopt</artifactId>
+      <groupId>gnu.getopt</groupId>
+      <artifactId>java-getopt</artifactId>
       <version>1.0.13</version>
     </dependency>
 	<!-- -->


### PR DESCRIPTION
The getopt dependency can not be found in maven central. I think this is the correct one and everything seems to work fine.
